### PR TITLE
feat: configure app from env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,10 @@ version = "1.0.0"
 edition = "2024"
 
 [dependencies]
+envy = "0.4"
 telers = { git = "https://github.com/Desiders/telers.git", rev = "66cce11018f9f3e8b4218697413d90e4c7253825", features = ["default_signal"] }
 tokio = { version = "1.36", features = ["macros"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+serde = { version = "1.0", features = ["derive"] }
+once_cell = "1"


### PR DESCRIPTION
bot now can be configured using env vars:

```bash
FB_TOKEN=12345:SoMeToKeN FB_FROM_ID=-1002193370548 FB_TO_ID=-1002216851397 cargo run
```